### PR TITLE
Fix(): namespace file update

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,7 @@ inputs:
     default: './'
   to:
     description: '(Namespace Files specific) Remote path to upload namespace files to'
-    required: false
-    default: /
+    default: "/"
   resource:
     description: 'Resource you want to update in your namespace, can be "flow" or "template"'
     required: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ if [[ $9 ]]; then
 fi
 
 if [[ $4 == "namespace_files" ]]; then
-  /app/kestra namespace files update "$1" "$2" "$3" --server="$5" "$auth" $delete "$tenant"
+  /app/kestra namespace files update "$1" "$2" "$3" --server="$5" "$auth" $delete $tenant
 else
-  /app/kestra "$4" namespace update "$1" "$2" --server="$5" "$auth" $delete "$tenant"
+  /app/kestra "$4" namespace update "$1" "$2" --server="$5" "$auth" $delete $tenant
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ if [[ $9 ]]; then
   tenant="--tenant=$9"
 fi
 
-if [[ $4 == 'namespace_files' ]]; then
+if [[ $4 == "namespace_files" ]]; then
   /app/kestra namespace files update "$1" "$2" "$3" --server="$5" "$auth" $delete "$tenant"
 else
   /app/kestra "$4" namespace update "$1" "$2" --server="$5" "$auth" $delete "$tenant"


### PR DESCRIPTION
Fix issue where not providing a would make the action crash

Was QA through this repo, can be reused : https://github.com/kestra-io/flow-namespace-update-github-action/actions/runs/7292197556/job/19872691071